### PR TITLE
TuiEditor namespace error and Get Tui-viewer

### DIFF
--- a/src/tui-editor.component.ts
+++ b/src/tui-editor.component.ts
@@ -14,7 +14,7 @@ import * as TuiEditor from 'tui-editor'
 })
 export class TuiComponent implements OnInit {
     @Input() options: object;
-    editor: TuiEditor;
+    editor: any;
     constructor(private editorService: TuiService) { }
     public ngOnInit() {
         this.getEditor();

--- a/src/tui-editor.service.ts
+++ b/src/tui-editor.service.ts
@@ -5,12 +5,21 @@ export class TuiService {
   editor: any;
   constructor() { }
   createEditor(options: object): any {
-    this.editor = new TuiEditor(Object.assign({
-      el: document.querySelector('.ngx-tui-editor'),
-      initialEditType: 'markdown',
-      previewStyle: 'vertical',
-      height: '300px'
-    }, options));
+    if (options.viewer) {
+      this.editor = TuiEditor.factory(Object.assign({
+            el: document.querySelector('.ngx-tui-editor'),
+            height: '300px'
+          },
+          options));
+    } else {
+      this.editor = new TuiEditor(Object.assign({
+            el: document.querySelector('.ngx-tui-editor'),
+            initialEditType: 'markdown',
+            previewStyle: 'vertical',
+            height: '300px'
+          },
+          options));
+    }
     return this.editor;
   }
   getMarkdown(): string {


### PR DESCRIPTION
First of all thank you for your wonderful project. 
And before you review this, please understand my lack of English.

I am using ngx-tui-editor in my project. But there were some issues in applying to the project.
1. Can't use namespace ‘TuiEditor’ as a type     #7 
2. Can't load Tui-viewer

I am modifying the code that I have installed and applying it to my project. It seems to be convenient.
