### PR TITLE
Support for multiple instances

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -84,19 +84,75 @@ export class AppComponent {
   }
 }
 ```
+
+#### Service Functions
 The following functions can be called on the TuiService:
 
 | Function | Use | Returns |
 | -------- | --- | ------- |
-| getMarkdown( ) | Gets markdown syntax text from editor | string |
-| getHtml( ) | Gets html syntax text from editor | string |
-| getSelectedText( ) | Gets only selected text from editor | string |
-| insertText(text: string) | Inserts plain text into editor | void |
-| setHtml(text: string) | Inserts html text and formats into markdown in editor | void |
-| setMarkdown(text: string) | Inserts markdown text and formats into markdown syntax in editor | void |
-| hide( ) | Hides the editor pane | void |
-| show( ) | Shows the editor pane | void |
+| getMarkdown(editorId?: string) | Gets markdown syntax text from editor | string |
+| getHtml(editorId?: string) | Gets html syntax text from editor | string |
+| getSelectedText(editorId?: string) | Gets only selected text from editor | string |
+| insertText(text: string, editorId?: string) | Inserts plain text into editor | void |
+| setHtml(text: string, editorId?: string) | Inserts html text and formats into markdown in editor | void |
+| setMarkdown(text: string, editorId?: string) | Inserts markdown text and formats into markdown syntax in editor | void |
+| hide(editorId?: string) | Hides the editor pane | void |
+| show(editorId?: string) | Shows the editor pane | void |
 
+#### Component Outputs
+
+| Attribute   | Required | Type | Default | Description |
+| ----------- | -------- | ---- | ----- | ----------- |
+| `loaded` | No | `void` |  | This event will fire when the editor has loaded |
+| `onChangeMarkdown` | No | `string` |  | This event will be fired when you done typing and will return the markdown string |
+| `onChangeHTML` | No | `string` |  | This event will be fired when you are typing and will return the rendered html string |
+| `onChange` | No | `MarkdownData: {html: string, markdown: string}` |  | This event will be fired when you are typing and will return both the html and markdown from the editor |
+| `onBlurMarkdown` | No | `string` |  | This event will be fired when the editor is blurred and will return the markdown string |
+| `onBlurHTML` | No | `string` |  | This event will be fired when the editor is blurred and will return the rendered html string |
+| `onBlur` | No | `string` |  | This event will be fired when the editor is blurred and will return both the html and markdown from the editor |
+
+**Example**
+
+```html
+<tui-editor
+  [options]="options"
+  (loaded)="editorLoaded()"
+  (onChange)="onChange($event)"
+  (onBlur)="onBlur($event)"
+></tui-editor>
+```
+
+## Setup with Multiple Instances
+You can track the editorService instance by passing in an `editorId` in the options object. When you need to use any of the functions in the `TuiService` you will use the optional `editorId` you passed in with the options input.
+
+### Example
+Setting the editor id in the options
+```typescript
+options : {
+            ...
+            editorId: 'MyEditorId',
+            ...
+          },
+```
+
+Passing the editorId into the service call
+
+```typescript
+import { TuiService } from 'ngx-tui-editor';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent {
+  constructor(private editorService: TuiService){}
+  setHtml(){
+    this.editorService.setHtml("<h1>Hello World</h1>", "MyEditorId");
+  }
+}
+```
 
 ## Development
 

--- a/src/tui-editor.component.ts
+++ b/src/tui-editor.component.ts
@@ -1,22 +1,71 @@
 import { TuiService } from './tui-editor.service';
-import { Component, OnInit, ViewEncapsulation, Input } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, Input, ViewChild, ElementRef, Output, EventEmitter } from '@angular/core';
+
+export interface MarkdownData {
+    html: string;
+    markdown: string;
+}
+
 @Component({
     selector: 'tui-editor',
     encapsulation: ViewEncapsulation.None,
     styleUrls: [
         './tui-editor.component.scss',
     ],
-    template: '<div class = "ngx-tui-editor"></div>',
+    template: '<div #editor class = "ngx-tui-editor"></div>',
 })
 export class TuiComponent implements OnInit {
+    @ViewChild('editor')
+    editorElement: ElementRef;
+
     @Input() options: object;
     editor: any;
+    events = {
+        change: this.loadedEditor.bind(this),
+        load: this.loadedEditor.bind(this),
+        blur: this.blur.bind(this),
+    };
+
+    @Output() loaded: EventEmitter<void> = new EventEmitter<void>();
+    @Output() onChangeMarkdown: EventEmitter<string> = new EventEmitter<string>();
+    @Output() onChangeHTML: EventEmitter<string> = new EventEmitter<string>();
+    @Output() onChange: EventEmitter<MarkdownData> = new EventEmitter<MarkdownData>();
+    @Output() onBlurMarkdown: EventEmitter<string> = new EventEmitter<string>();
+    @Output() onBlurHTML: EventEmitter<string> = new EventEmitter<string>();
+    @Output() onBlur: EventEmitter<MarkdownData> = new EventEmitter<MarkdownData>();
+
     constructor(private editorService: TuiService) { }
     public ngOnInit() {
         this.getEditor();
     }
 
     async getEditor() {
-        this.editor = await this.editorService.createEditor(this.options);
+        this.editor = await this.editorService.createEditor({
+            events: this.events,
+            ...this.options,
+            el: this.editorElement.nativeElement,
+        });
+    }
+
+    loadedEditor() {
+        this.loaded.emit();
+    }
+
+    changed() {
+        this.onChangeMarkdown.emit(this.editor.getMarkdown((this.options as any).editorId));
+        this.onChangeHTML.emit(this.editor.getHtml((this.options as any).editorId));
+        this.onChange.emit({
+            html: this.editor.getHtml((this.options as any).editorId),
+            markdown: this.editor.getMarkdown((this.options as any).editorId),
+        });
+    }
+
+    blur() {
+        this.onBlurMarkdown.emit(this.editor.getMarkdown((this.options as any).editorId));
+        this.onBlurHTML.emit(this.editor.getHtml((this.options as any).editorId));
+        this.onBlur.emit({
+            html: this.editor.getHtml((this.options as any).editorId),
+            markdown: this.editor.getMarkdown((this.options as any).editorId),
+        });
     }
 }

--- a/src/tui-editor.service.ts
+++ b/src/tui-editor.service.ts
@@ -2,41 +2,70 @@ import { Injectable } from '@angular/core';
 import Editor from 'tui-editor'
 @Injectable()
 export class TuiService {
-  editor: any;
+  editor: any = {};
+  defaultId = 'ngx-editor-default';
   constructor() { }
   createEditor(options: any): any {
-      this.editor = Editor.factory(Object.assign({
-            el: document.querySelector('.ngx-tui-editor'),
-            initialEditType: 'markdown',
-            previewStyle: 'vertical',
-            height: '300px'
-          },
-          options));
+    const id = options.editorId || this.defaultId;
+    this.editor[id] = Editor.factory(Object.assign({
+      el: document.querySelector('.ngx-tui-editor'),
+      initialEditType: 'markdown',
+      previewStyle: 'vertical',
+      height: '300px'
+    },
+    options));
   
-    return this.editor;
+    return this.editor[id];
   }
-  getMarkdown(): string {
-    return this.editor.getMarkdown();
+  getMarkdown(id?: string): string {
+    id = id || this.defaultId;
+    if (this.editor && this.editor[id]) {
+      return this.editor[id].getMarkdown();
+    }
+    return '';
   }
-  getHtml(): string {
-    return this.editor.getHtml();
+  getHtml(id?: string): string {
+    id = id || this.defaultId;
+    if (this.editor && this.editor[id]) {
+      return this.editor[id].getHtml();
+    }
+    return '';
   }
-  getSelectedText(): string {
-    return this.editor.getSelectedText();
+  getSelectedText(id?: string): string {
+    id = id || this.defaultId;
+    if (this.editor && this.editor[id]) {
+      return this.editor[id].getSelectedText();
+    }
+    return '';
   }
-  insertText(text: string) {
-    this.editor.insertText(text)
+  insertText(text: string, id?: string) {
+    id = id || this.defaultId;
+    if (this.editor && this.editor[id]) {
+      this.editor[id].insertText(text);
+    }
   }
-  setHtml(text: string) {
-    this.editor.setHtml(text)
+  setHtml(text: string, id?: string) {
+    id = id || this.defaultId;
+    if (this.editor && this.editor[id]) {
+      this.editor[id].setHtml(text);
+    }
   }
-  setMarkdown(text: string) {
-    this.editor.setMarkdown(text)
+  setMarkdown(text: string, id?: string) {
+    id = id || this.defaultId;
+    if (this.editor && this.editor[id]) {
+      this.editor[id].setMarkdown(text);
+    }
   }
-  hide() {
-    return this.editor.hide();
+  hide(id?: string) {
+    id = id || this.defaultId;
+    if (this.editor && this.editor[id]) {
+      return this.editor[id].hide();
+    }
   }
-  show() {
-    return this.editor.show();
+  show(id?: string) {
+    id = id || this.defaultId;
+    if (this.editor && this.editor[id]) {
+      return this.editor[id].show();
+    }
   }
 }


### PR DESCRIPTION
## Description
This PR adds support for multiple instances of a `tui-editor` in a single page.

## What changed
- Updated the service to allow users to specify a `editorId` so they can target a specific editor instance
- Updated the component to use `ViewChild` so that we can specify a specific editor instance in the DOM rather than using css selectors.
- Updated the component to support `Outputs` that way users can receive updates for the editor as an event
- Updated the README to document how to use the new features.

## What problem does this solve?
I believe this could solve  issue #3 